### PR TITLE
Remove the validation check for the Web App URL in script.js.

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,11 +61,6 @@ document.addEventListener('DOMContentLoaded', () => {
     async function submitReport(e) {
         e.preventDefault();
 
-		if (WEB_APP_URL === 'https://script.google.com/macros/s/AKfycbxC2GMVUYiag-R3pIljThXgeuKc2yVSVqyfb9qyyrpK4kU7LqZzJRq9HihMYJU3DP0/exec') {
-            showError('Error: La URL del script no ha sido configurada en script.js.');
-            return;
-        }
-
         showLoading(true);
 		hideMessages();
 


### PR DESCRIPTION
The check was causing an error message to appear, preventing form submission. After a lengthy discussion with the user, it was determined that their provided Web App URL was identical to the placeholder URL that the check was validating against.

To unblock the user and respect their provided URL, this check has been removed. This resolves the immediate issue of the error message and allows the form submission to proceed.