### PR TITLE
Fix: Normalize Google Sheet headers for robust data mapping

### DIFF
--- a/inventario/js/google-sheets.js
+++ b/inventario/js/google-sheets.js
@@ -73,18 +73,35 @@ class GoogleSheetsAPI {
         });
     }
 
+    normalizeHeader(header) {
+        const upperHeader = (header || '').toUpperCase().trim();
+        const headerMap = {
+            'CUSTODIO RESPONSABLE': 'RESPONSABLE',
+            'Nº': 'N°',
+            'NO.': 'N°',
+            'NUMERO': 'N°',
+            'SERIALES': 'SERIAL',
+            'ETIQUETAS': 'ETIQUETA',
+            'OBSERVACION': 'OBSERVACIONES',
+            'ESTADO': 'STATUS'
+        };
+        return headerMap[upperHeader] || upperHeader;
+    }
+
     parseGoogleVisualization(response) {
         if (!response || !response.table || !response.table.cols || !response.table.rows) {
             console.warn("La respuesta de Google Visualization API no tiene el formato esperado.");
             return [];
         }
 
-        const headers = response.table.cols.map(col => col.label || col.id);
+        const headers = response.table.cols.map(col => this.normalizeHeader(col.label || col.id));
+
         const data = response.table.rows.map(row => {
             const item = {};
             headers.forEach((header, index) => {
+                if (!header) return; // Ignorar columnas sin cabecera
                 const cell = row.c[index];
-                item[header] = cell ? (cell.f || cell.v) : ''; // Priorizar valor formateado 'f' si existe
+                item[header] = cell ? (cell.f || cell.v) : ''; // Priorizar valor formateado 'f'
             });
             return item;
         });


### PR DESCRIPTION
This commit introduces a header normalization mechanism to make the data parsing from Google Sheets more flexible and robust.

Previously, the application required exact, case-sensitive matches for column headers, causing fields like 'RESPONSABLE' to be missed if the Google Sheet used a variation like 'CUSTODIO RESPONSABLE'.

The new `normalizeHeader` function in `google-sheets.js` automatically maps common variations and converts headers to a standard format before processing. This ensures that data is correctly mapped and displayed in the application, preventing issues caused by minor differences in column naming in the source sheet.